### PR TITLE
Horizontal scroll issue on page 404

### DIFF
--- a/src/app/(home)/[not-found]/notFound.module.scss
+++ b/src/app/(home)/[not-found]/notFound.module.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	width: 100vw;
+	width: 100%;
 	height: calc(100vh - 148px);
 	background-color: var(--color-silver-gray);
 


### PR DESCRIPTION
Removed horizontal scrolling of the 404 page. Scrolling was caused by specifying the width of the page content in units. "vw", which is not entirely correct, and the content did not fit into the container. Problem solution: changed the unit of measure. by %, thereby the content will automatically be equal to the width of the container.