### PR TITLE
Incorrect mobile view of date element on Profit money page

### DIFF
--- a/src/app/(privateProfile)/profitMoney/profitMoney.module.scss
+++ b/src/app/(privateProfile)/profitMoney/profitMoney.module.scss
@@ -88,7 +88,7 @@
 
 	@media (max-width: 490px) {
 		& {
-			height: 82px;
+			height: 100%;
 			gap: 14px;
 		}
 	}
@@ -140,7 +140,7 @@
 
 	@media (max-width: 490px) {
 		& {
-			padding: 10px 26px;
+			padding: 10px 15px;
 			width: 49%;
 			gap: 4px;
 		}


### PR DESCRIPTION
Fixed the date display on the mobile income page. Adjusted the padding and set the height to 100%.