### PR TITLE
Activation page loading effect issue

### DIFF
--- a/src/app/(home)/activate/page.tsx
+++ b/src/app/(home)/activate/page.tsx
@@ -54,6 +54,11 @@ const Activate = () => {
 	}, []);
 
 	useEffect(() => {
+		if (!uid || !token) {
+			setLoad(true);
+			return;
+		}
+		
 		const activateUser = async () => {
 			try {
 				const isLocalhost =


### PR DESCRIPTION
Added an infinite loading effect on the activation page when the uid and token parameters are missing in the URL.