### PR TITLE
Text tip for strong password

### DIFF
--- a/src/app/(privateProfile)/savings/page.tsx
+++ b/src/app/(privateProfile)/savings/page.tsx
@@ -17,6 +17,7 @@ import {
 import { ISavingsInputForm, ISavingsSelectForm } from "../../../types/pages/Savings";
 import SavingsTransaction from "../../../components/userProfileLayout/savingsTransaction/savingsTransaction";
 import AppInput from "../../../ui/appInput/AppInput";
+import InputDate from "../../../ui/inputDate/inputDate";
 import { CategorySelect } from "../../../components/userProfileLayout/categorySelect/CategorySelect";
 import AddButton from "../../../components/userProfileLayout/addButton/addButton";
 import { savingsTransactions } from "../../../mocks/SavingsTransaction";
@@ -220,7 +221,7 @@ function Savings() {
 							</div>
 							<div className={styles.dateSelectionWrapper}>
 								<p className={styles.dateSelectionWrapper__description}>Выбор даты</p>
-								<AppInput control={control} label={"Выбор даты"} type={InputTypeList.Date} name={"date"} />
+								<InputDate control={control} name={"date"} /> {}
 							</div>
 						</div>
 						<div className={styles.savingsDetailsContainer}>

--- a/src/ui/authInput/AuthInput.tsx
+++ b/src/ui/authInput/AuthInput.tsx
@@ -9,7 +9,7 @@ import { InputTypeList } from "../../helpers/Input";
 import { defaultOptions } from "../../helpers/passwordStrengthOption";
 import { TAuthInputForm, IAuthInput } from "../../types/common/UiKitProps";
 import showPassword from "../../assets/pages/signUp/showPassword.svg";
-import { errorPasswordStrengthMedium } from "../../helpers/authConstants";
+import { errorPasswordStrengthMedium, errorPasswordStrengthStrong } from "../../helpers/authConstants";
 
 import styles from "./AuthInput.module.scss";
 
@@ -17,6 +17,7 @@ const AuthInput = ({ label, type, placeholder, autoComplete, subtitle, error, ..
 	const { field, fieldState } = useController<TAuthInputForm>(props);
 	const [passwordType, setPasswordType] = useState<InputTypeList>(InputTypeList.Password);
 	const [isMediumPassword, setIsMediumPassword] = useState(false);
+	const [isStrongPassword, setIsStrongPassword] = useState(false);
 	const togglePasswordVisibility = () =>
 		setPasswordType(passwordType === InputTypeList.Password ? InputTypeList.Text : InputTypeList.Password);
 
@@ -25,9 +26,11 @@ const AuthInput = ({ label, type, placeholder, autoComplete, subtitle, error, ..
 			try {
 				const result = passwordStrength(field.value, defaultOptions);
 				setIsMediumPassword(result.value === "Medium");
+				setIsStrongPassword(result.value === "Strong"); 
 				// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 			} catch (error: unknown) {
 				setIsMediumPassword(false);
+				setIsStrongPassword(false);
 			}
 		}
 	}, [field.value, type]);
@@ -62,6 +65,11 @@ const AuthInput = ({ label, type, placeholder, autoComplete, subtitle, error, ..
 					{errorPasswordStrengthMedium}
 				</p>
 			)}
+			{!fieldState.error && !error && isStrongPassword && (
+                <p className={cn(styles.inputWrap__subtitle, styles.inputWrap__subtitle_green)}>
+                    {errorPasswordStrengthStrong}
+                </p>
+            )}
 
 			{subtitle && !error && <p className={styles.inputWrap__subtitle}>{subtitle}</p>}
 		</div>


### PR DESCRIPTION
This pull request introduces a new feature to the AuthInput component that provides immediate visual feedback to users regarding the strength of their password.
-A new useState hook (isStrongPassword) was added to AuthInput to specifically track the "Strong" password status. 
-The useEffect hook in AuthInput.tsx was updated to evaluate the password strength