### PR TITLE
Error displaying field headers in personal account settings

### DIFF
--- a/src/ui/appInput/AppInput.module.scss
+++ b/src/ui/appInput/AppInput.module.scss
@@ -70,11 +70,6 @@
 		}
 	}
 
-	@media (max-width: 490px) {
-		& {
-			display: none;
-		}
-	}
 }
 
 .inputWrap__subtitle {


### PR DESCRIPTION
In 360x640 resolution, field headers are not displayed in the user's personal account settings

1 Open the page https://qa.freenance.store/

2 Login

3 On the loaded application page, click on the user icon in the upper left corner, you will be redirected to your personal account.

4 In the personal account menu, select the item "Change password"

3 Compare the page with the layout

Expected Result: The page matches the layout. The field header is displayed above each input field.
Actual Result: When changing the resolution to 360x640, field headers are not displayed