### PR TITLE
The password change window is not positioned according to the figma layout

### DIFF
--- a/src/app/(home)/changePassword/changePassword.module.scss
+++ b/src/app/(home)/changePassword/changePassword.module.scss
@@ -37,31 +37,9 @@
 	background-color: var(--color-pure-light);
 	box-shadow: 0px 4px 20px 0px var(--color-black-eight-part);
 	border-radius: 12px;
-	margin-top: 180px;
-
-	@media (max-width: 1440px) {
-		margin-top: 140px;
-	}
-
-	@media (max-width: 1100px) {
-		& {
-			margin-top: 580px;
-			margin-right: 170px;
-		}
-	}
-
-	@media (max-width: 850px) {
-		& {
-			margin-top: 126px;
-			margin-right: 6px;
-		}
-	}
 
 	@media (max-width: 550px) {
-		& {
-			margin-top: 60px;
 			width: 332px;
-		}
 	}
 
 	&__content {

--- a/src/app/(home)/changePassword/changePassword.module.scss
+++ b/src/app/(home)/changePassword/changePassword.module.scss
@@ -39,7 +39,7 @@
 	border-radius: 12px;
 
 	@media (max-width: 550px) {
-			width: 332px;
+		width: 332px;
 	}
 
 	&__content {

--- a/src/components/mainLayout/changePasswordModal/changePasswordModal.module.scss
+++ b/src/components/mainLayout/changePasswordModal/changePasswordModal.module.scss
@@ -5,6 +5,7 @@
 	height: 100vh;
 	top: 0;
 	left: 0;
+	border: none;
 	z-index: 20;
 }
 

--- a/src/components/mainLayout/changePasswordModal/changePasswordModal.module.scss
+++ b/src/components/mainLayout/changePasswordModal/changePasswordModal.module.scss
@@ -7,10 +7,12 @@
 	left: 0;
 	border: none;
 	z-index: 20;
+	display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .changePasswordResponseModalWrap {
-	margin-top: 10%;
 	margin-inline: auto;
 	width: 560px;
 	height: 324px;


### PR DESCRIPTION
Descriptions:

The "Change password" window for entering and confirming a new password after resetting it is shifted below the center in all resolutions

Pre-conditions:

User is registered

1 Open the page https://qa.freenance.store/login

2 Click on "forgot password"

3 Enter the registered user's email in the field, click the "recover" button

4 An email with a link to reset the password will be sent to the email, follow the link from the email

5 Compare the loaded page for changing and confirming the new password with the layout

Expected result: The page matches the layout in all resolutions available in the layout

Actual result: The "Change password" window is shifted below the center in all resolutions available in the layout